### PR TITLE
fix: small typo

### DIFF
--- a/content/code.md
+++ b/content/code.md
@@ -8,7 +8,7 @@ You can download the ZIP file containing all the code discussed in the book
 from WILEY's page for the book [here](https://www.wiley.com/en-in/Practical+Go%3A+Building+Scalable+Network+and+Non+Network+Applications-p-9781119773818). Look for the DOWNLOADS
 section.
 
-You can also clone the git repostiory from [here](https://github.com/practicalgo/code).
+You can also clone the git repository from [here](https://github.com/practicalgo/code).
 
 
 ## Solutions to Exercises
@@ -18,4 +18,4 @@ from WILEY's page for the book [here](https://www.wiley.com/en-in/Practical+Go%3
 section.
 
 
-You can also clone the git repostiory from [here](https://github.com/practicalgo/book-exercise-solutions/).
+You can also clone the git repository from [here](https://github.com/practicalgo/book-exercise-solutions/).

--- a/public/code/index.html
+++ b/public/code/index.html
@@ -34,12 +34,12 @@
         <h1>Code</h1><time>December 8, 2021</time></header><p>You can download the ZIP file containing all the code discussed in the book
 from WILEY&rsquo;s page for the book <a href="https://www.wiley.com/en-in/Practical+Go%3A+Building+Scalable+Network+and+Non+Network+Applications-p-9781119773818">here</a>. Look for the DOWNLOADS
 section.</p>
-<p>You can also clone the git repostiory from <a href="https://github.com/practicalgo/code">here</a>.</p>
+<p>You can also clone the git repository from <a href="https://github.com/practicalgo/code">here</a>.</p>
 <h2 id="solutions-to-exercises">Solutions to Exercises</h2>
 <p>You can download the ZIP file containing the solutions to the exercises in the book
 from WILEY&rsquo;s page for the book <a href="https://www.wiley.com/en-in/Practical+Go%3A+Building+Scalable+Network+and+Non+Network+Applications-p-9781119773818">here</a>. Look for the DOWNLOADS
 section.</p>
-<p>You can also clone the git repostiory from <a href="https://github.com/practicalgo/book-exercise-solutions/">here</a>.</p>
+<p>You can also clone the git repository from <a href="https://github.com/practicalgo/book-exercise-solutions/">here</a>.</p>
 </article>
 <footer id="footer">
     Post managed in a <a href="https://github.com/amitsaha/echorand.me">git repo</a> | <a href="https://github.com/amitsaha/echorand.me/commit/dadbdaa6260d5bb8b6a7f6e4dd9201403696b8d1">Last Commit on this post </a>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -15,7 +15,7 @@
     <lastmod>2021-12-08T08:31:17+11:00</lastmod>
   </url><url>
     <loc>https://practicalgobook.net/</loc>
-    <lastmod>2021-12-18T18:06:25+11:00</lastmod>
+    <lastmod>2021-12-19T21:43:57+11:00</lastmod>
   </url><url>
     <loc>https://practicalgobook.net/categories/</loc>
     <lastmod>2021-09-24T15:07:11+10:00</lastmod>


### PR DESCRIPTION
Found a typo at https://practicalgobook.net/code/, as below:

Before:
![image](https://user-images.githubusercontent.com/1259313/146979382-7d89baa2-1269-4abb-8174-6a8878bf0c22.png)

After:
![image](https://user-images.githubusercontent.com/1259313/146979416-7365e39a-ce72-4de8-ac81-8ec0d88cc927.png)
